### PR TITLE
コンテナ起動時に初期データを登録するようにした

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     ports:
       - 3306:3306
     volumes:
+      - ./initdb.d/createdb.sql:/docker-entrypoint-initdb.d/createdb.sql:ro
       - mysql_data:/var/lib/mysql
 volumes:
   mysql_data:


### PR DESCRIPTION
コンテナ起動時に初期データを登録するようにします。

`/docker-entrypoint-initdb.d` にsqlファイルを置くことで、コンテナ起動時に自動的に読み込まれるようになります。
参考: https://hub.docker.com/_/mysql